### PR TITLE
Init script depends on package if managed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,13 @@ class mariadb (
     }
   }
 
-  if $mariadb::service_name {
+  if $mariadb::manage_package_name and $mariadb::service_name {
+    service { $mariadb::service_name:
+      ensure     => $mariadb::manage_service_ensure,
+      enable     => $mariadb::manage_service_enable,
+      require    => Package[$mariadb::manage_package_name]
+    }
+  } elsif $mariadb::service_name {
     service { $mariadb::service_name:
       ensure     => $mariadb::manage_service_ensure,
       enable     => $mariadb::manage_service_enable,


### PR DESCRIPTION
The init script needs to require the package if the packaged is maintained by the module. Otherwise the following error is issued:

```
Error: /Stage[main]/Mariadb/Service[mysql]: Could not evaluate: Could not find i
nit script for 'mysql'
```

PS: I tried to match your coding style. I'm sure there is a better solution regarding DRY, but I'm not very familiar with Ruby/Puppet.
